### PR TITLE
Add the ability to turn off spans on a row level

### DIFF
--- a/source/lib/row/row.js
+++ b/source/lib/row/row.js
@@ -24,6 +24,7 @@ class Row {
      * @property {String} firstColumnAlpha Alpha representation of the first column of the row containing data
      * @property {Number} lastColumn Index of the last column of the row cotaining data
      * @property {String} lastColumnAlpha Alpha representation of the last column of the row containing data
+     * @property {Boolean} spansEnabled States whether the spans optimization is enabled on this row, by default true
      */
     constructor(row, ws) {
         this.ws = ws;
@@ -38,6 +39,7 @@ class Row {
         this.s = null;
         this.thickBot = null;
         this.thickTop = null;
+        this.spansEnabled = true;
     }
 
     set height(h) {

--- a/source/lib/worksheet/builder.js
+++ b/source/lib/worksheet/builder.js
@@ -156,7 +156,7 @@ let _addSheetData = (promiseObj) => {
                 let rEle = ele.ele('row');
 
                 rEle.att('r', thisRow.r);
-                rEle.att('spans', thisRow.spans);
+                thisRow.spansEnabled === true ? rEle.att('spans', thisRow.spans) : null;
                 thisRow.s !== null ? rEle.att('s', thisRow.s) : null;
                 thisRow.customFormat !== null ? rEle.att('customFormat', thisRow.customFormat) : null;
                 thisRow.ht !== null ? rEle.att('ht', thisRow.ht) : null;


### PR DESCRIPTION
amekkawi/excel4node/issues/97

This will allow us to turn off spans when it is not needed, by default we will keep it on as to make it backwards compatible.

